### PR TITLE
폰트 개선

### DIFF
--- a/src/common/style.pcss
+++ b/src/common/style.pcss
@@ -1,7 +1,20 @@
+@import url(@fortawesome/fontawesome-free/css/all.min.css);
+@import url(https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Noto+Sans+KR:wght@400;700&display=swap);
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 ::-webkit-scrollbar { width:8px; height:8px }
+
+@layer components {
+    :root {
+        --font-family-sans: "Noto Sans KR", "Noto Sans JP", "Malgun Gothic", "Dotum", sans-serif;
+    }
+
+    :lang(ja) {
+        --font-family-sans: "Noto Sans JP", sans-serif;
+        font-family: var(--font-family-sans);
+    }
+}
 
 html.dark {
     ::-webkit-scrollbar-track{ background-color:#111 }

--- a/src/page/admin/anime.vue
+++ b/src/page/admin/anime.vue
@@ -21,7 +21,7 @@
             <tr class="border-b dark:border-zinc-800">
               <th class="py-4 px-6 w-[20%] text-zinc-500 dark:text-zinc-300">원제</th>
               <td class="py-4 px-6">
-                <input type="text" v-model="anime.originalSubject" name="originalSubject" placeholder="원제" class="p-2.5 as-input-text">
+                <input type="text" v-model="anime.originalSubject" name="originalSubject" placeholder="원제" class="p-2.5 as-input-text" lang="ja">
               </td>
             </tr>
             <tr class="border-b dark:border-zinc-800">
@@ -191,12 +191,12 @@
             <div>
               <router-link v-if="!node.agendaNo" :to="toAnimeViewUrl(node.animeNo)">
                 <div class="text-md font-bold text-gray-800 dark:text-zinc-300">{{node.subject}}</div>
-                <div class="text-sm mt-1" v-if="node.originalSubject">{{node.originalSubject}}</div>
+                <div class="text-sm mt-1" lang="ja" v-if="node.originalSubject">{{node.originalSubject}}</div>
               </router-link>
               <div v-else>
                 <input type="button" value="복원" @click="doRecover(node)" class="float-right text-white bg-rose-700 hover:bg-rose-800 outline-none font-medium rounded-md text-sm px-4 py-2 dark:bg-red-800 dark:hover:bg-red-700" />
                 <div class="text-md font-bold text-gray-800 dark:text-zinc-300">{{node.subject}}</div>
-                <div class="text-sm mt-1" v-if="node.originalSubject">{{node.originalSubject}}</div>
+                <div class="text-sm mt-1" lang="ja" v-if="node.originalSubject">{{node.originalSubject}}</div>
               </div>
             </div>
             <div class="mt-1 space-x-1 space-y-2 text-gray-800 dark:text-zinc-300">

--- a/src/page/schedule/2009.vue
+++ b/src/page/schedule/2009.vue
@@ -98,7 +98,7 @@ onBeforeUnmount(() => {
 #sc2009 {
   position: absolute; top:0; right:0; bottom:0; left:0; background-color: #444;
   background-image: url('/src/page/schedule/2009/bg.jpg'); background-repeat: no-repeat;
-  font-family: "Malgun Gothic", "Dotum"; min-width:530px; box-sizing: border-box;
+  font-family: "Malgun Gothic", "Dotum", sans-serif; min-width:530px; box-sizing: border-box;
   ::-webkit-scrollbar{ width:0; height:0 }
   a { text-decoration: none }
   > * { position: absolute; }

--- a/src/page/schedule/2015.vue
+++ b/src/page/schedule/2015.vue
@@ -173,7 +173,6 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-@import url(//fonts.googleapis.com/earlyaccess/notosanskr.css);
 @keyframes sc2015-popup {
   from { background-color: rgba(0, 0, 0, 0); } to { background-color: rgba(0, 0, 0, .3); }
 }
@@ -188,7 +187,7 @@ onBeforeUnmount(() => {
 #sc2015 .title svg:hover { opacity: 1; transform: rotate(22deg); }
 #sc2015 .nav th { height: 40px; cursor: pointer; transition: background-color 0.2s, color 0.2s; }
 #sc2015 .main { position: fixed; right:0; bottom:0; left:0; overflow-y:auto }
-#sc2015 .list { font-size:16px; font-family: "Noto Sans KR", "Malgun Gothic", "Dotum"; }
+#sc2015 .list { font-size:16px; }
 #sc2015 .list td { height: 48px; line-height: 1.8; padding:0; transition: background-color 0.2s, color 0.2s; }
 #sc2015 .list td.tod { width:64px; text-align: center; }
 #sc2015 .list td.genres { text-align: right; padding-right:14px; }

--- a/src/page/site/anime.vue
+++ b/src/page/site/anime.vue
@@ -5,7 +5,7 @@
     <div v-if="anime" class="mt-3 mb-10">
       <div v-if="anime.animeNo != 0">
         <div class="font-bold text-xl">{{anime.subject}}</div>
-        <div class="text-sm mt-1">{{anime.originalSubject}}</div>
+        <div class="text-sm mt-1" lang="ja">{{anime.originalSubject}}</div>
 
         <table class="mt-6 text-sm text-left text-gray-800 dark:text-gray-100 border-t border-gray-200 dark:border-zinc-800">
           <tbody>
@@ -172,7 +172,7 @@
             <div>
               <router-link :to="toAnimeViewUrl(node.animeNo)">
                 <div class="text-md font-bold text-gray-800 dark:text-zinc-300">{{node.subject}}</div>
-                <div class="text-sm mt-1" v-if="node.originalSubject">{{node.originalSubject}}</div>
+                <div class="text-sm mt-1" lang="ja" v-if="node.originalSubject">{{node.originalSubject}}</div>
               </router-link>
             </div>
             <div class="mt-1 space-x-1 space-y-2 text-gray-800 dark:text-zinc-300">

--- a/src/page/site/layout.vue
+++ b/src/page/site/layout.vue
@@ -153,9 +153,6 @@ onUnmounted(() => {
 </script>
 
 <style>
-@import url(@fortawesome/fontawesome-free/css/all.min.css);
-@import url(//fonts.googleapis.com/earlyaccess/notosanskr.css);
-body { font-family: "Noto Sans KR", "Malgun Gothic", "Dotum"; }
 .as-fa-spin {
   animation: fa-spin 4s infinite linear !important;
 }

--- a/src/page/site/schedule.vue
+++ b/src/page/site/schedule.vue
@@ -107,7 +107,7 @@
             <input type="number" v-model="asd.htmlHeight" class="shadow-sm block w-[48px] text-center text-zinc-900 outline-0 bg-zinc-50 rounded-md border border-zinc-300 dark:bg-zinc-900 dark:border-zinc-800 dark:text-white shadow-sm" maxlength="3" />
           </div>
           <label class="sub-title">HTML 코드</label>
-          <textarea readonly :value="htmlCode" class="p-2 h-[120px] md:h-[162px] as-input-text !text-[12px]"></textarea>
+          <textarea readonly :value="htmlCode" class="p-2 h-[120px] md:h-[162px] as-input-text !text-[12px] font-mono"></textarea>
           <div class="mt-3">
             <button @click="doCopyClipboard(htmlCode)" class="w-full p-2 as-input-btn font-semibold !text-[15px]">
               <i class="fa-regular fa-copy"></i>&nbsp; 복사하기
@@ -150,7 +150,7 @@
             <span class="ml-3 text-sm font-medium text-gray-900 dark:text-zinc-300">스크롤 사용여부</span>
           </label>
           <label class="sub-title">HTML 코드</label>
-          <textarea readonly :value="imgCode" class="p-2 h-[88px] md:h-[162px]  as-input-text !text-[12px]"></textarea>
+          <textarea readonly :value="imgCode" class="p-2 h-[88px] md:h-[162px]  as-input-text !text-[12px] font-mono"></textarea>
           <div class="mt-3">
             <button @click="doCopyClipboard(imgCode)" class="w-full p-2 as-input-btn font-semibold !text-[15px]">
               <i class="fa-regular fa-copy"></i>&nbsp; 복사하기

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,7 +5,11 @@ module.exports = {
         "./src/**/*.{vue,js,ts,jsx,tsx}",
     ],
     theme: {
-        extend: {},
+        extend: {
+            fontFamily: {
+                'sans': ['var(--font-family-sans)'],
+            },
+        },
     },
     plugins: [],
     darkMode: 'class'

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,6 +8,8 @@ module.exports = {
         extend: {
             fontFamily: {
                 'sans': ['var(--font-family-sans)'],
+                'serif': ['Georgia', 'Cambria', '"Times New Roman"', 'Times', 'serif'],
+                'mono': ['SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', '"Liberation Mono"', '"Courier New"', 'monospace'],
             },
         },
     },


### PR DESCRIPTION
 * 폰트 패밀리를 테일윈드가 관리하도록 수정하였습니다. 테일윈드는 `<html>` 태그를 대상으로 sans 폰트에 해당하는 폰트가 자동 적용되도록 설계되어 있습니다. 따라서 기존 코드는 전역 font-family 부분이 중복되었는데, 이를 해소하여 웹페이지 로딩 용량이 소폭 줄어들 것으로 예상됩니다.
 * 일본어 부분에 lang 속성을 추가하여 브라우저가 이것이 일본어다라고 인식할 수 있도록 하였으며 일본어 부분은 일본어 폰트가 나오도록 수정했습니다.
 * HTML 코드를 복사하는 부분에 고정폭이 나오도록 수정했습니다. 코드인 만큼 고정폭 폰트가 나오는 것이 맞고, 유튜브도 소스 코드 부분에는 고정폭 폰트가 나오도록 되어 있습니다.
 * 테일윈드 기본 폰트 패밀리에 `ui-`로 시작하는 곳을 지웠습니다. 현재로써는 사파리밖에 지원을 안하는 데다가 윈도우 환경의 크롬 등에 지원을 하더라도 윈도우 환경에서 글꼴의 가독성이 저하될 수 있습니다.